### PR TITLE
Fix sleep time series API call

### DIFF
--- a/lib/fitbit_api/sleep.rb
+++ b/lib/fitbit_api/sleep.rb
@@ -25,9 +25,9 @@ module FitbitAPI
       end
 
       if period
-        result = get("user/#{user_id}/activities/#{resource}/date/#{format_date(end_date)}/#{period}.json", opts)
+        result = get("user/#{user_id}/sleep/#{resource}/date/#{format_date(end_date)}/#{period}.json", opts)
       else
-        result = get("user/#{user_id}/activities/#{resource}/date/#{format_date(start_date)}/#{format_date(end_date)}.json", opts)
+        result = get("user/#{user_id}/sleep/#{resource}/date/#{format_date(start_date)}/#{format_date(end_date)}.json", opts)
       end
       # remove root key from response
       result.values[0]


### PR DESCRIPTION
# 📝  Overview

I really appreciate you putting this gem together!  I noticed one of the API endpoints for sleep points to the activities API.  I'm not sure if this is a typo, or if FitBit's APIs evolved over time to separate sleep out.  I've tested this change locally and it appears to work.  Let me know if you'd be open to merging this into your repository, cheers!