### PR TITLE
get_token and refresh_token! do not become bad requests

### DIFF
--- a/lib/fitbit_api/client.rb
+++ b/lib/fitbit_api/client.rb
@@ -177,7 +177,7 @@ module FitbitAPI
     end
 
     def auth_headers
-      { 'Authorization' => "Basic #{Base64.encode64("#{@client_id}:#{@client_secret}")}" }
+      { 'Authorization' => "Basic #{Base64.strict_encode64("#{@client_id}:#{@client_secret}")}" }
     end
 
     def default_request_headers


### PR DESCRIPTION
## Overview
The current get_token and refresh_token become Bad requests.
Because Base64.encode64 returns a character that includes a newline at the end of the line.
Base64.strict_encode64 returns a result that does not include a newline at the end, so modify it to use Base64.strict_encode64 instead of Base64.encode64.

## Environment
Ruby (2.7.7p221)
oauth2 (1.4.11)
faraday (2.7.10)
faraday-httpclient (2.0.1)
faraday-net_http (3.0.2)

## Current
```
c = FitbitAPI::Client.new( access_token: 'hoge', refresh_token: 'huga', user_id: '-', expires_at: nil)
c.get_token 'huga' (or fc.refresh_token!)
```

returns
```
OAuth2::Error: <html>
<head><title>400 Bad Request</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<hr><center>cloudflare</center>
</body>
</html>
```
