### PR TITLE
Remove unused values from default params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.0.1
+-----
+- Remove unused values from default params for the following:
+  - activity_logs_list
+  - ecg_logs_list
+  - sleep_logs_list
+- Fixes bad request errors for `activity_logs_list` endpoint.
+
 1.0.0
 -----
 - BREAKING: Upgrade `oauth2` dependency to v2.0

--- a/lib/fitbit_api/activities.rb
+++ b/lib/fitbit_api/activities.rb
@@ -61,7 +61,7 @@ module FitbitAPI
     # @option params :limit [Integer] The max of the number of entries returned (max: 20)
 
     def activity_logs_list(params = {})
-      default_params = { before_date: Date.today, after_date: nil, sort: 'desc', limit: 20, offset: 0 }
+      default_params = { before_date: Date.today, sort: 'desc', limit: 20, offset: 0 }
       get("user/#{user_id}/activities/list.json", default_params.merge(params))
     end
 

--- a/lib/fitbit_api/electrocardiogram.rb
+++ b/lib/fitbit_api/electrocardiogram.rb
@@ -16,7 +16,7 @@ module FitbitAPI
     # @option params :limit [Integer] The max of the number of entries returned (max: 10)
 
     def ecg_logs_list(params = {})
-      default_params = { before_date: Date.today, after_date: nil, sort: 'desc', limit: 10, offset: 0 }
+      default_params = { before_date: Date.today, sort: 'desc', limit: 10, offset: 0 }
       get("user/#{user_id}/ecg/list.json", default_params.merge(params))
     end
   end

--- a/lib/fitbit_api/sleep.rb
+++ b/lib/fitbit_api/sleep.rb
@@ -50,7 +50,7 @@ module FitbitAPI
     # @option params :limit [Integer] The max of the number of entries returned (max: 100)
 
     def sleep_logs_list(params = {})
-      default_params = { before_date: Date.today, after_date: nil, sort: 'desc', limit: 20, offset: 0 }
+      default_params = { before_date: Date.today, sort: 'desc', limit: 20, offset: 0 }
       get("user/#{user_id}/sleep/list.json", default_params.merge(params))
     end
 

--- a/lib/fitbit_api/version.rb
+++ b/lib/fitbit_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FitbitAPI
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
Recently, the Fitbit API appears to throw bad request errors if passing empty params to some of its endpoints - in particular it would error out on the activity logs list endpoint as both the beforeDate and afterDate params are being sent over, even though the afterDate param is null by default. Previously, it looks like Fitbit's API would gracefully handle these nil params but in this case it explicitly fails as you can't have both a before and after date set at the same time.

This updates affected methods so that unused values are removed from the default params objects. There should be no difference in behavior other than fixing the recently broken activity logs endpoint.

Addresses https://github.com/zokioki/fitbit_api/issues/12